### PR TITLE
Migrate from deprecated serde_yml to serde-saphyr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Migrate YAML parsing from deprecated `serde_yml` to `serde-saphyr`, a maintained pure-Rust YAML library (resolves RUSTSEC-2025-0068)
+- Update all dependencies to latest compatible versions
 
 ## [0.6.6] - 2026-05-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Migrate YAML parsing from deprecated `serde_yml` to `serde-saphyr`, a maintained pure-Rust YAML library (resolves RUSTSEC-2025-0068)
+
 ## [0.6.6] - 2026-05-21
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,9 +154,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytes"
@@ -446,9 +446,9 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -472,9 +472,9 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "encode_unicode"
@@ -761,9 +761,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
 dependencies = [
  "bytes",
  "itoa",
@@ -800,9 +800,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "eb92f162bf56536459fc83c79b974bb12837acfed43d6bc370a7916d0ae15ecc"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1088,9 +1088,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.98"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1145,9 +1145,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "lru-slab"
@@ -1157,9 +1157,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "mime"
@@ -1544,9 +1544,9 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64",
  "bytes",
@@ -1813,9 +1813,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -2133,9 +2133,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.10"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "bitflags",
  "bytes",
@@ -2336,9 +2336,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2349,9 +2349,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.71"
+version = "0.4.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2359,9 +2359,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2369,9 +2369,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2382,9 +2382,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
@@ -2425,9 +2425,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.98"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2844,18 +2844,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "bce33a6288fa3f072a8c2c7d0f2fdbb90e28298f0135c1f99b96c3db2efcc60b"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "8fd425244944f4ab65ccff928e7323354c5a018c75838362fdce749dfad2ee1e"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,36 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "annotate-snippets"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f211a51805bc641f3ad5b7664c77d2547af685cc33b4cd8d31964027a46f13f1"
+dependencies = [
+ "anstyle",
+ "memchr",
+ "unicode-width",
 ]
 
 [[package]]
@@ -68,10 +92,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arraydeque"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
@@ -456,6 +492,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding_rs_io"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83"
+dependencies = [
+ "encoding_rs",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -646,6 +691,16 @@ dependencies = [
  "r-efi 6.0.0",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "granit-parser"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f50ba32164f9e098d5da618776a32afbb32270adcbe3d3d006107dae11e37c91"
+dependencies = [
+ "arraydeque",
+ "smallvec",
 ]
 
 [[package]]
@@ -1062,16 +1117,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
-name = "libyml"
-version = "0.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
-dependencies = [
- "anyhow",
- "version_check",
-]
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1140,6 +1185,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
+
+[[package]]
 name = "num-modular"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1152,6 +1203,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "537b596b97c40fcf8056d153049eb22f481c17ebce72a513ec9286e4986d1bb6"
 dependencies = [
  "num-modular",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -1646,12 +1706,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
-name = "ryu"
-version = "1.0.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
-
-[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1719,6 +1773,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-saphyr"
+version = "0.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5897b4c3faadadd35fdb6689f015641f3bc481d5adaaac56231ea15aeb243db3"
+dependencies = [
+ "ahash",
+ "annotate-snippets",
+ "base64",
+ "encoding_rs_io",
+ "getrandom 0.3.4",
+ "granit-parser",
+ "nohash-hasher",
+ "num-traits",
+ "serde",
+ "smallvec",
+ "zmij",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1758,21 +1831,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
-]
-
-[[package]]
-name = "serde_yml"
-version = "0.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
-dependencies = [
- "indexmap",
- "itoa",
- "libyml",
- "memchr",
- "ryu",
- "serde",
- "version_check",
 ]
 
 [[package]]
@@ -2223,8 +2281,8 @@ dependencies = [
  "reqwest",
  "semver",
  "serde",
+ "serde-saphyr",
  "serde_json",
- "serde_yml",
  "tempfile",
  "thiserror",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ reqwest = "0.13.3"
 semver = "1.0.28"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde_yml = "0.0.12"
+serde-saphyr = "0.0.27"
 thiserror = "2"
 tempfile = "3.27.0"
 tokio = { version = "1.52.3", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ handlebars = "6.4.0"
 indicatif = { version = "0.18.4", features = ["rayon"] }
 lazy_static = "1.5.0"
 regex = "1.12.3"
-reqwest = "0.13.3"
+reqwest = "0.13.4"
 semver = "1.0.28"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src/command/topology/model.rs
+++ b/src/command/topology/model.rs
@@ -39,7 +39,7 @@ impl TopologySetup {
     pub fn load(path: &Path, registry: &WildFlyImageRegistry) -> anyhow::Result<TopologySetup> {
         let content = std::fs::read_to_string(path)
             .with_context(|| format!("Failed to read topology file: {}", path.display()))?;
-        let setup: TopologySetup = serde_yml::from_str(&content)
+        let setup: TopologySetup = serde_saphyr::from_str(&content)
             .with_context(|| format!("Failed to parse topology file: {}", path.display()))?;
         setup.validate(registry)?;
         resolve_version(&setup.version, registry)
@@ -125,6 +125,10 @@ impl<'de> de::Visitor<'de> for VersionVisitor {
         formatter.write_str("a version number (e.g. 34, 26.1) or 'dev'")
     }
 
+    fn visit_i64<E: de::Error>(self, v: i64) -> Result<String, E> {
+        Ok(v.to_string())
+    }
+
     fn visit_u64<E: de::Error>(self, v: u64) -> Result<String, E> {
         Ok(v.to_string())
     }
@@ -149,13 +153,7 @@ fn deserialize_optional_version<'de, D>(deserializer: D) -> Result<Option<String
 where
     D: de::Deserializer<'de>,
 {
-    Option::<serde_yml::Value>::deserialize(deserializer)?
-        .map(|v| match v {
-            serde_yml::Value::Number(n) => Ok(n.to_string()),
-            serde_yml::Value::String(s) => Ok(s),
-            _ => Err(de::Error::custom("expected a version number or 'dev'")),
-        })
-        .transpose()
+    deserialize_version(deserializer).map(Some)
 }
 
 impl ServerSetup {
@@ -191,7 +189,7 @@ hosts:
   - name: dc
     domain-controller: true
 "#;
-        let setup: TopologySetup = serde_yml::from_str(yaml).unwrap();
+        let setup: TopologySetup = serde_saphyr::from_str(yaml).unwrap();
         assert_eq!(setup.name, "test-topology");
         assert_eq!(setup.version, "34");
         assert_eq!(setup.hosts.len(), 1);
@@ -209,7 +207,7 @@ hosts:
   - name: dc
     domain-controller: true
 "#;
-        let setup: TopologySetup = serde_yml::from_str(yaml).unwrap();
+        let setup: TopologySetup = serde_saphyr::from_str(yaml).unwrap();
         assert_eq!(setup.version, "dev");
     }
 
@@ -222,7 +220,7 @@ hosts:
   - name: dc
     domain-controller: true
 "#;
-        let setup: TopologySetup = serde_yml::from_str(yaml).unwrap();
+        let setup: TopologySetup = serde_saphyr::from_str(yaml).unwrap();
         assert_eq!(setup.version, "26.1");
     }
 
@@ -237,7 +235,7 @@ hosts:
       - name: server-one
         group: main-server-group
 "#;
-        let setup: TopologySetup = serde_yml::from_str(yaml).unwrap();
+        let setup: TopologySetup = serde_saphyr::from_str(yaml).unwrap();
         assert_eq!(setup.hosts.len(), 2);
         assert!(setup.hosts[0].name.is_none());
         assert!(setup.hosts[1].name.is_none());
@@ -268,7 +266,7 @@ hosts:
       - name: server-one
         group: main-server-group
 "#;
-        let setup: TopologySetup = serde_yml::from_str(yaml).unwrap();
+        let setup: TopologySetup = serde_saphyr::from_str(yaml).unwrap();
         assert_eq!(setup.hosts.len(), 3);
         assert_eq!(setup.hc_hosts().len(), 2);
         assert_eq!(setup.dc_host().name, Some("dc".to_string()));
@@ -295,7 +293,7 @@ hosts:
   - name: host1
     version: 33
 "#;
-        let setup: TopologySetup = serde_yml::from_str(yaml).unwrap();
+        let setup: TopologySetup = serde_saphyr::from_str(yaml).unwrap();
         let host1 = &setup.hosts[1];
         assert_eq!(host1.effective_version("34"), "33");
         assert_eq!(setup.dc_host().effective_version("34"), "34");
@@ -313,7 +311,7 @@ hosts:
       - name: server-two
         group: other-server-group
 "#;
-        let setup: TopologySetup = serde_yml::from_str(yaml).unwrap();
+        let setup: TopologySetup = serde_saphyr::from_str(yaml).unwrap();
         assert!(setup.validate(&test_registry()).is_ok());
         let servers = &setup.hosts[1].servers;
         assert!(servers[0].group.is_none());
@@ -335,7 +333,7 @@ version: 34
 hosts:
   - name: host1
 "#;
-        let setup: TopologySetup = serde_yml::from_str(yaml).unwrap();
+        let setup: TopologySetup = serde_saphyr::from_str(yaml).unwrap();
         let result = setup.validate(&test_registry());
         assert!(result.is_err());
         assert!(
@@ -357,7 +355,7 @@ hosts:
   - name: dc2
     domain-controller: true
 "#;
-        let setup: TopologySetup = serde_yml::from_str(yaml).unwrap();
+        let setup: TopologySetup = serde_saphyr::from_str(yaml).unwrap();
         let result = setup.validate(&test_registry());
         assert!(result.is_err());
         assert!(
@@ -379,7 +377,7 @@ hosts:
   - name: host1
   - name: host1
 "#;
-        let setup: TopologySetup = serde_yml::from_str(yaml).unwrap();
+        let setup: TopologySetup = serde_saphyr::from_str(yaml).unwrap();
         let result = setup.validate(&test_registry());
         assert!(result.is_err());
         assert!(
@@ -403,7 +401,7 @@ hosts:
       - name: server-one
         group: invalid-group
 "#;
-        let setup: TopologySetup = serde_yml::from_str(yaml).unwrap();
+        let setup: TopologySetup = serde_saphyr::from_str(yaml).unwrap();
         let result = setup.validate(&test_registry());
         assert!(result.is_err());
         assert!(
@@ -428,7 +426,7 @@ hosts:
       - name: server-two
         group: other-server-group
 "#;
-        let setup: TopologySetup = serde_yml::from_str(yaml).unwrap();
+        let setup: TopologySetup = serde_saphyr::from_str(yaml).unwrap();
         assert!(setup.validate(&test_registry()).is_ok());
     }
 
@@ -443,7 +441,7 @@ hosts:
   - name: host1
     version: dev
 "#;
-        let setup: TopologySetup = serde_yml::from_str(yaml).unwrap();
+        let setup: TopologySetup = serde_saphyr::from_str(yaml).unwrap();
         assert!(setup.validate(&test_registry()).is_ok());
         assert_eq!(setup.hosts[1].version, Some("dev".to_string()));
         assert_eq!(setup.hosts[1].effective_version("34"), "dev");
@@ -460,7 +458,7 @@ hosts:
   - name: host1
     version: 26.1
 "#;
-        let setup: TopologySetup = serde_yml::from_str(yaml).unwrap();
+        let setup: TopologySetup = serde_saphyr::from_str(yaml).unwrap();
         assert_eq!(setup.hosts[1].version, Some("26.1".to_string()));
         assert_eq!(setup.hosts[1].effective_version("34"), "26.1");
     }


### PR DESCRIPTION
## Summary

- Replace deprecated `serde_yml` with `serde-saphyr`, a maintained pure-Rust YAML library
- Resolves RUSTSEC-2025-0068 (unsafe C-FFI `libyml` dependency removed from graph)
- Simplify `deserialize_optional_version` to reuse `VersionVisitor` instead of `Value`-based matching

## Test plan

- [x] All 114 tests pass
- [x] `cargo clippy` clean
- [x] Topology YAML parsing works for integer, dotted, and string versions

Supersedes #59